### PR TITLE
Reduce amount of resources requested by ctlplane components

### DIFF
--- a/manifest/ctlplane-daemon.yaml
+++ b/manifest/ctlplane-daemon.yaml
@@ -47,11 +47,8 @@ spec:
                 - all
           resources:
             limits:
-              cpu: 2
-              memory: "128M"
-            requests:
-              cpu: 1
-              memory: "64M"    
+              cpu: "100m"
+              memory: "16M"
       containers:
         - name: ctlplane-daemonset
           image: IMAGE
@@ -73,11 +70,11 @@ spec:
             mountPath: /daemonstate
           resources:
             limits:
-              cpu: 4
-              memory: "512M"
-            requests:
-              cpu: 2
+              cpu: "100m"
               memory: "64M"
+            requests:
+              cpu: "100m"
+              memory: "32M"
           readinessProbe:
             grpc:
               port: 31000
@@ -111,11 +108,11 @@ spec:
                   fieldPath: spec.nodeName
           resources:
             limits:
-              cpu: 4
-              memory: "512M"
-            requests:
-              cpu: 2
+              cpu: "100m"
               memory: "64M"
+            requests:
+              cpu: "100m"
+              memory: "32M"
       volumes:
         - name: host
           hostPath:


### PR DESCRIPTION
When I was deploying `ctlplane`, I realized most of its components were requesting a lot of CPU and memory resources.
I took a look to the metrics I gathered from Prometheus and I was able to improve this a little bit.
Please, let me know if I'm missing something here in case you see I'm reducing CPU and Memory requests more than I should.

![Screen Shot 2022-12-29 at 12 12 41 PM](https://user-images.githubusercontent.com/7405871/210007226-c5e767f1-9474-453e-a48f-114aae0ee299.png)
